### PR TITLE
trocar nodemon por node

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "src/index.js",
   "scripts": {
-    "start": "nodemon src/server.js",
+    "start": "node src/server.js",
     "test": "cross-env NODE_ENV=test jest"
   },
   "keywords": [],


### PR DESCRIPTION
# Necessidade de trocar o nodemon por node
#### O nodemon é utilizado apenas em versão de desenvolvimento, pois ao salvar arquivos modificados ele restarta a aplicação. E como ele está nas dependências de Dev o heroku não consegue subir a aplicação.

- [x] Trocar nodemon por node no package json

##### Esta branch vai ficar disponível apenas para o heroku